### PR TITLE
Add bzlmod module support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,13 @@
+module (
+    name = "rules_helm",
+    version = "0.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.7")
+
+helm_configure = use_extension("@rules_helm//:extensions.bzl", "helm_configure")
+
+use_repo(helm_configure, "sh_helm_get_toolchains")
+
+register_toolchains("@sh_helm_get_toolchains//:all")

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,6 @@
+load("//:repo.bzl", "helm_register_toolchains")
+
+def _helm_configure_impl(ctx):
+    helm_register_toolchains(register = False)
+
+helm_configure = module_extension(implementation = _helm_configure_impl)

--- a/repo.bzl
+++ b/repo.bzl
@@ -12,7 +12,7 @@ helm_toolchain(
 )
 """
 
-def helm_register_toolchains(name="sh_helm_get", version="3.10.2"):
+def helm_register_toolchains(name="sh_helm_get", version="3.10.2", register = True):
     current_version = VERSIONS[version]
     for platform in current_version:
         settings = current_version[platform]
@@ -23,8 +23,8 @@ def helm_register_toolchains(name="sh_helm_get", version="3.10.2"):
             strip_prefix = platform,
             build_file_content = _BUILD_FILE_CONTENT,
         )
-
-        native.register_toolchains("@{}_toolchains//:{}_toolchain".format(name, platform))
+        if register:
+            native.register_toolchains("@{}_toolchains//:{}_toolchain".format(name, platform))
 
     toolchains_repo(
         name = name + "_toolchains",


### PR DESCRIPTION
## Intent
This PR adds bzlmod support to rules_helm, so it can easily be consumed as an external dependency.

I've bumped the version to 0.2.0, as it's safer to pull from built versions than GitHub generated zip files, It would be appreciated if a new release could be created if this is merged.

MODULE.bazel doesn't allow for the use of `native.register_toolchains` so it's disabled when called as a bzlmod module

I've tested this in my own environment (darwin-amd64) and it seems to work well.

## Usage
To use as a bzlmod module:

1. Add rules_helm to your registry


2. Define your upstream helm charts as a module extension:
```
# third-party/helm/deps.bzl

load("@rules_helm//:helm.bzl", "helm_repo_chart")

def helm_dependencies(ctx):

    helm_repo_chart(
        name = "io_jetstack_charts_cert_manager",
        chart = "cert-manager",
        version = "1.8.2",
        urls = ["https://charts.jetstack.io/charts/cert-manager-v1.8.2.tgz"],
        sha256 = "3e3262f08455d02f025e803b8227dea3ff3f88c170bfb0655b513fa274de5592",
    )

helm_deps = module_extension(implementation = helm_dependencies)
```

3. Configure MODULE.bazel
```
# MODULE.bazel

bazel_dep(name = "rules_helm", version = "0.1.0")

helm_deps = use_extension("//third-party/helm:deps.bzl", "helm_deps")

use_repo(
    helm_deps, 
    "io_jetstack_charts_cert_manager",
)
```

4. Reference charts as normal:
```
# some/BUILD.bazel

load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")
load("@rules_helm//:helm.bzl", "helm_template")

jsonnet_to_json(
    name = "values",
    src = "values.jsonnet",
    outs = ["values.yaml"],
)

helm_template(
    name = "cert-manager-template",
    chart = "@io_jetstack_charts_cert_manager//:chart",
    namespace = "cert-manager",
    values = ":values",
)
```